### PR TITLE
Reduce head space above the tallest bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3794,45 +3794,13 @@
       }
     },
     "replot-core": {
-      "version": "git+ssh://git@github.com/MacroConnections/replot-core.git#76fde89ffa4e5ed08469da2bcef1afa8fef24a8a",
+      "version": "git+ssh://git@github.com/MacroConnections/replot-core.git#8ba991dd38bc560ef6efc2438bfe89729da49a96",
       "requires": {
-        "babel-core": "6.24.1",
-        "babel-loader": "6.4.1",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-react": "6.24.1",
-        "concat-map": "0.0.1",
-        "eslint": "3.19.0",
-        "eslint-plugin-react": "6.10.3",
         "humanize-plus": "1.8.2",
-        "react": "15.6.2",
-        "react-dom": "15.6.2",
-        "react-motion": "0.4.8",
-        "webpack": "2.6.1"
+        "prop-types": "15.5.10",
+        "react-motion": "0.4.8"
       },
       "dependencies": {
-        "react": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-          "requires": {
-            "create-react-class": "15.6.3",
-            "fbjs": "0.8.12",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.5.10"
-          }
-        },
-        "react-dom": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
-          "requires": {
-            "fbjs": "0.8.12",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.5.10"
-          }
-        },
         "react-motion": {
           "version": "0.4.8",
           "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.4.8.tgz",

--- a/src/BarGraph.jsx
+++ b/src/BarGraph.jsx
@@ -192,7 +192,7 @@ class BarGraph extends React.Component {
     xVals = xVals.sort((a,b) => a-b)
     let yVals = this.props.data.map(item => item[this.props.yKey])
     let maxY = Math.max(...yVals)
-    let padY = maxY / 5
+    let padY = maxY / 16
 
     let xLabels
     if (this.props.groupKey) {


### PR DESCRIPTION
When combined with the change in https://github.com/MacroConnections/replot-core/pull/33:

![headspace_after](https://user-images.githubusercontent.com/25045998/36080679-8713de22-0f61-11e8-904c-52adc3efba55.png)

@sanjaypojo @AlmahaAlmalki #17